### PR TITLE
Ensure Google Fonts link uses complete URL on a single line

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@900&family=Nunito+Sans:opsz,wght@6..12,400;6..12,700&display=swap" rel="stylesheet">
-
     <link href="assets/css/base.css" rel="stylesheet">
     <link href="assets/css/components.css" rel="stylesheet">
     <link href="assets/css/pages/home.css" rel="stylesheet">


### PR DESCRIPTION
## Summary
- keep Google Fonts stylesheet URL on a single line and verify the href

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d42f2f208331ab401f86323a67f0