### PR TITLE
Replace invalid website icon with globe

### DIFF
--- a/assets/data/colaboradores/colaboradores.json
+++ b/assets/data/colaboradores/colaboradores.json
@@ -27,7 +27,7 @@
             "imagen": "assets/images/colab-3.svg",
             "social": {
                 "linkedin": "#",
-                "website": "#"
+                "globe": "#"
             }
         }
     ]


### PR DESCRIPTION
## Summary
- fix collaborator social icon key by replacing invalid `website` with Bootstrap's `globe`

## Testing
- `python -m json.tool assets/data/colaboradores/colaboradores.json`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d439105483319b5efb7a902ba0e7