### PR TITLE
feat: honor system dark mode preference

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -56,6 +56,17 @@ body.dark-mode {
     --border-color: #495057;
 }
 
+@media (prefers-color-scheme: dark) {
+    :root {
+        --background-color: #212529;
+        --card-background-color: #2c3138;
+        --text-color: #f8f9fa;
+        --muted-text-color: #adb5bd;
+        --heading-color: #f8f9fa;
+        --border-color: #495057;
+    }
+}
+
 body {
     background-color: var(--background-color);
     color: var(--text-color);

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -17,18 +17,23 @@ document.addEventListener('DOMContentLoaded', () => {
     // Establecer el tema al cargar la página
     if (storedTheme) {
         applyTheme(storedTheme);
-    } else if (userPrefersDark.matches) {
-        applyTheme('dark');
     } else {
-        applyTheme('light');
+        applyTheme(userPrefersDark.matches ? 'dark' : 'light');
     }
+
+    // Actualizar si la preferencia del sistema cambia y no hay tema guardado
+    userPrefersDark.addEventListener('change', (e) => {
+        if (!localStorage.getItem('theme')) {
+            applyTheme(e.matches ? 'dark' : 'light');
+        }
+    });
 
     // Escuchar el evento de clic en el botón
     if (toggleBtn) {
         toggleBtn.addEventListener('click', () => {
             let currentTheme = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
             let newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-            
+
             localStorage.setItem('theme', newTheme);
             applyTheme(newTheme);
         });


### PR DESCRIPTION
## Summary
- apply system dark color scheme variables with `prefers-color-scheme`
- adjust theme toggler to default to OS preference and react to changes

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e65d1dbc8331923de0baa179adad