### PR TITLE
Centralize contact CTA styles

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -56,3 +56,15 @@
     font-weight: bold;
     letter-spacing: 0.5px;
 }
+
+/* --- Reutilizable: Sección CTA de Contacto --- */
+.contact-cta-section {
+    background-color: #0d6efd;
+    color: #fff;
+    padding: 6rem 0;
+}
+
+.contact-cta-section h2 {
+    font-family: var(--font-heading);
+    font-weight: 900;
+}

--- a/assets/css/pages/project.css
+++ b/assets/css/pages/project.css
@@ -33,8 +33,3 @@
 .project-gallery-section .hover-grow:hover {
     transform: scale(1.02);
 }
-
-/* CTA Final */
-.contact-cta-section {
-    background-color: #0d6efd;
-}

--- a/assets/css/pages/servicios.css
+++ b/assets/css/pages/servicios.css
@@ -33,17 +33,6 @@
     font-weight: 600;
 }
 
-/* --- CTA Final (Mismos estilos que en index.css) --- */
-.contact-cta-section {
-    background-color: #0d6efd;
-    color: #fff;
-    padding: 6rem 0;
-}
-
-.contact-cta-section h2 {
-    font-family: var(--font-heading);
-    font-weight: 900;
-}
 
 /* --- Sección de Planes y Precios --- */
 .planes-section {

--- a/assets/css/pages/sobre-mi.css
+++ b/assets/css/pages/sobre-mi.css
@@ -29,15 +29,3 @@
     transform: translateY(-5px);
     box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.175) !important;
 }
-
-/* --- CTA Final (Mismos estilos que en index.css) --- */
-.contact-cta-section {
-    background-color: #0d6efd;
-    color: #fff;
-    padding: 6rem 0;
-}
-
-.contact-cta-section h2 {
-    font-family: var(--font-heading);
-    font-weight: 900;
-}

--- a/legal/cookies.html
+++ b/legal/cookies.html
@@ -27,6 +27,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@900&family=Nunito+Sans:opsz,wght@6..12,400;6..12,700&display=swap" rel="stylesheet">
 
     <link href="../assets/css/base.css" rel="stylesheet">
+    <link href="../assets/css/components.css" rel="stylesheet">
     <link href="../assets/css/pages/legales.css" rel="stylesheet">
 
     <script src="../assets/js/seo.js" defer></script>

--- a/legal/politica-privacidad.html
+++ b/legal/politica-privacidad.html
@@ -27,6 +27,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@900&family=Nunito+Sans:opsz,wght@6..12,400;6..12,700&display=swap" rel="stylesheet">
 
     <link href="../assets/css/base.css" rel="stylesheet">
+    <link href="../assets/css/components.css" rel="stylesheet">
     <link href="../assets/css/pages/legales.css" rel="stylesheet">
 
     <script src="../assets/js/seo.js" defer></script>

--- a/legal/terminos-condiciones.html
+++ b/legal/terminos-condiciones.html
@@ -30,6 +30,7 @@
         rel="stylesheet">
 
     <link href="../assets/css/base.css" rel="stylesheet">
+    <link href="../assets/css/components.css" rel="stylesheet">
     <link href="../assets/css/pages/legales.css" rel="stylesheet">
 
     <script src="../assets/js/seo.js" defer></script>


### PR DESCRIPTION
## Summary
- Consolidate `.contact-cta-section` styling in `assets/css/components.css`
- Remove duplicated CTA styles from `sobre-mi.css`, `servicios.css`, and `project.css`
- Ensure every HTML page imports `components.css`, including legal pages

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e65fe50c833180fa8238f91af155