### PR TITLE
Enviar formulario de contacto a endpoint y validar en frontend

### DIFF
--- a/assets/js/pages/contacto.js
+++ b/assets/js/pages/contacto.js
@@ -1,19 +1,45 @@
 (function () {
-  'use strict'
+  'use strict';
 
-  // Selecciona el formulario que necesita validación
-  const form = document.querySelector('.needs-validation')
+  const form = document.getElementById('contact-form');
+  if (!form) return;
 
-  // Añade un 'event listener' para cuando el formulario intente ser enviado
-  form.addEventListener('submit', function (event) {
-    // Si el formulario no es válido, evita que se envíe
+  const alertBox = document.getElementById('form-alert');
+  const endpoint = 'https://formspree.io/f/maygbkvd'; // Reemplaza con tu endpoint
+
+  form.addEventListener('submit', async function (event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    alertBox.classList.add('d-none');
+
     if (!form.checkValidity()) {
-      event.preventDefault()
-      event.stopPropagation()
+      form.classList.add('was-validated');
+      return;
     }
 
-    // Agrega la clase de validación de Bootstrap al formulario
-    // Esto mostrará los mensajes de error/éxito
-    form.classList.add('was-validated')
-  }, false)
-})()
+    form.classList.add('was-validated');
+    const formData = new FormData(form);
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Accept': 'application/json' },
+        body: formData
+      });
+
+      if (response.ok) {
+        alertBox.textContent = 'Mensaje enviado con éxito.';
+        alertBox.className = 'alert alert-success mt-3';
+        form.reset();
+        form.classList.remove('was-validated');
+      } else {
+        throw new Error('Error en la respuesta');
+      }
+    } catch (err) {
+      alertBox.textContent = 'Ocurrió un error al enviar el mensaje. Inténtalo de nuevo más tarde.';
+      alertBox.className = 'alert alert-danger mt-3';
+    }
+  });
+})();
+

--- a/contacto.html
+++ b/contacto.html
@@ -81,7 +81,7 @@
                 <div class="row">
                     <div class="col-lg-6 mb-4">
                         <h3 class="h4 fw-bold mb-3" data-i18n="form_titulo">Envía un Mensaje</h3>
-                        <form action="mailto:tu-email@ejemplo.com" method="post" enctype="text/plain">
+                        <form id="contact-form" class="needs-validation" novalidate method="post">
                             <div class="mb-3">
                                 <label for="nombre" class="form-label" data-i18n="form_nombre">Tu Nombre</label>
                                 <input type="text" class="form-control" id="nombre" name="nombre" required>
@@ -95,10 +95,8 @@
                                 <textarea class="form-control" id="mensaje" name="mensaje" rows="4" required></textarea>
                             </div>
                             <button type="submit" class="btn btn-primary btn-lg fw-bold w-100" data-i18n="btn_enviar">Enviar Mensaje</button>
+                            <div id="form-alert" class="alert d-none mt-3" role="alert"></div>
                         </form>
-                        <div class="text-center mt-4">
-                            <p class="text-muted" data-i18n="aviso_mailto">Al hacer clic en "Enviar", se abrirá tu aplicación de correo para completar el envío.</p>
-                        </div>
                     </div>
 
                     <div class="col-lg-6">
@@ -179,5 +177,6 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="assets/js/main.js"></script>
+    <script src="assets/js/pages/contacto.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Reemplazo del envío `mailto` por formulario con validación y llamada a endpoint.
- Integración de script específico de contacto para manejar éxito y errores.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c43bf7aae88331ae17394da0272936