### PR TITLE
Refactor project loading to use shared function

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -20,11 +20,14 @@ document.addEventListener('DOMContentLoaded', function() {
     // - Funcionalidad para un botón de "volver arriba".
 
     (function () {
-  const SRC = '/assets/data/projects.json'; // <-- ajusta la ruta si es necesario
+  const SRC = '/assets/data/portfolio/projects.json';
 
   // Obtiene una imagen desde el objeto del proyecto, sea string o { webp, jpg, src, alt }
   function pickImage(item) {
     if (!item) return { src: '', alt: 'Proyecto' };
+    if (item.imagen_min) {
+      return { src: item.imagen_min, alt: item.imagen_alt || item.titulo || item.title || item.name || 'Proyecto' };
+    }
     if (typeof item.image === 'string') {
       return { src: item.image, alt: item.image_alt || item.title || item.name || 'Proyecto' };
     }
@@ -41,21 +44,26 @@ document.addEventListener('DOMContentLoaded', function() {
         return { src: first.webp || first.jpg || first.src || '', alt: first.alt || 'Proyecto' };
       }
     }
-    return { src: '', alt: item.title || item.name || 'Proyecto' };
+    return { src: '', alt: item.title || item.name || item.titulo || 'Proyecto' };
   }
 
   function cardHTML(item) {
-    const title   = item.title || item.name || '';
-    const excerpt = item.excerpt || item.description || item.summary || '';
-    const url     = item.url || item.link || (item.slug ? `/proyectos/${item.slug}.html` : '#');
+    const title   = item.title || item.name || item.titulo || item.nombre || '';
+    const excerpt = item.excerpt || item.description || item.summary || item.descripcion || '';
+    const urlSlug = item.slug || item.id || '';
+    const url     = item.url || item.link || (urlSlug ? `portfolio/${urlSlug}.html` : '#');
     const img     = pickImage(item);
+    const categories = (item.categoria || item.categories || [])
+      .map(cat => `<span class="badge bg-primary mb-2">${cat}</span>`)
+      .join('');
 
     return `
-      <article class="card h-100 shadow-sm">
+      <article class="card h-100 border-0 shadow-sm rounded-4 overflow-hidden project-card">
         ${img.src ? `<img src="${img.src}" class="card-img-top" alt="${img.alt}" loading="lazy">` : ``}
-        <div class="card-body">
-          ${title ? `<h3 class="h5 card-title mb-2">${title}</h3>` : ``}
-          ${excerpt ? `<p class="card-text text-muted mb-3">${excerpt}</p>` : ``}
+        <div class="card-body p-4 text-center">
+          ${categories}
+          ${title ? `<h3 class="card-title fw-bold fs-5">${title}</h3>` : ``}
+          ${excerpt ? `<p class="card-text text-muted">${excerpt}</p>` : ``}
           ${url ? `<a href="${url}" class="btn btn-outline-primary btn-sm">Ver proyecto</a>` : ``}
         </div>
       </article>
@@ -69,12 +77,13 @@ document.addEventListener('DOMContentLoaded', function() {
     try {
       const res = await fetch(src, { cache: 'no-store' });
       const data = await res.json();
-      const items = Array.isArray(data) ? data : (data.projects || data.items || []);
+      const items = Array.isArray(data) ? data : (data.projects || data.proyectos || data.items || []);
       if (!Array.isArray(items)) return;
 
       (limit ? items.slice(0, limit) : items).forEach(item => {
         const col = document.createElement('div');
-        col.className = 'col';
+        const categories = item.categoria || item.categories || [];
+        col.className = 'col project-item ' + categories.join(' ');
         col.innerHTML = cardHTML(item);
         grid.appendChild(col);
       });
@@ -83,16 +92,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   }
 
-  document.addEventListener('DOMContentLoaded', () => {
-    // Home: primeros 4
-    if (document.getElementById('home-projects-list')) {
-      loadProjects('#home-projects-list', { limit: 4 });
-    }
-    // Portfolio: todos
-    if (document.getElementById('portfolio-projects-list')) {
-      loadProjects('#portfolio-projects-list');
-    }
-  });
+  window.loadProjects = loadProjects;
 })();
 
 });

--- a/assets/js/pages/home.js
+++ b/assets/js/pages/home.js
@@ -1,32 +1,9 @@
 document.addEventListener('DOMContentLoaded', function() {
 
     // --- Carga dinámica de Proyectos en la página de inicio ---
-    const projectListContainer = document.getElementById('home-projects-list');
-
-    fetch('assets/data/portfolio/projects.json')
-        .then(response => response.json())
-        .then(data => {
-            // Mostrar solo los 3 primeros proyectos para la página de inicio
-            const projectsToShow = data.proyectos.slice(0, 3); 
-            projectsToShow.forEach(project => {
-                const projectCardHTML = `
-                    <div class="col-lg-4 mb-4">
-                        <a href="portfolio/${project.id}.html" class="text-decoration-none">
-                            <div class="card h-100 border-0 shadow-sm rounded-4 overflow-hidden home-project-card">
-                                <img src="${project.imagen_min}" class="card-img-top" alt="Captura de pantalla del ${project.titulo}">
-                                <div class="card-body text-center">
-                                    <h3 class="card-title fw-bold fs-5">${project.titulo}</h3>
-                                    <p class="card-text text-muted">${project.descripcion}</p>
-                                </div>
-                            </div>
-                        </a>
-                    </div>
-                `;
-                projectListContainer.insertAdjacentHTML('beforeend', projectCardHTML);
-            });
-        })
-        .catch(error => console.error('Error al cargar proyectos:', error));
-
+    if (window.loadProjects) {
+        loadProjects('#home-projects-list', { limit: 3 });
+    }
 
     // --- Carga dinámica de Colaboradores ---
     const collaboratorsList = document.getElementById('collaborators-list');

--- a/assets/js/pages/portfolio.js
+++ b/assets/js/pages/portfolio.js
@@ -1,59 +1,29 @@
 document.addEventListener('DOMContentLoaded', function() {
-    const projectListContainer = document.getElementById('project-list');
-    // Seleccionar botones de filtrado dentro del contenedor con id "filter-buttons"
     const filterButtons = document.querySelectorAll('#filter-buttons .btn[data-filter]');
 
-    // Función para renderizar los proyectos en el HTML
-    function renderProjects(projects) {
-        projectListContainer.innerHTML = ''; // Limpiar el contenedor
-        projects.forEach(project => {
-            const categories = project.categoria.map(cat => `<span class="badge bg-primary mb-2">${cat}</span>`).join('');
-            const projectCardHTML = `
-                <div class="col project-item ${project.categoria.join(' ')}">
-                    <a href="portfolio/${project.id}.html" class="text-decoration-none">
-                        <div class="card h-100 border-0 shadow-sm rounded-4 overflow-hidden project-card">
-                            <img src="${project.imagen_min}" class="card-img-top" alt="Captura de pantalla del ${project.titulo}">
-                            <div class="card-body p-4">
-                                ${categories}
-                                <h3 class="card-title fw-bold">${project.titulo}</h3>
-                                <p class="card-text text-muted">${project.descripcion}</p>
-                            </div>
-                        </div>
-                    </a>
-                </div>
-            `;
-            projectListContainer.insertAdjacentHTML('beforeend', projectCardHTML);
-        });
-    }
+    if (window.loadProjects) {
+        loadProjects('#project-list').then(() => {
+            const allProjects = document.querySelectorAll('#project-list .project-item');
 
-    // Cargar los datos desde el archivo JSON
-    fetch('assets/data/portfolio/projects.json')
-        .then(response => {
-            if (!response.ok) {
-                throw new Error('No se pudo cargar el archivo projects.json');
+            function applyFilter(filter) {
+                allProjects.forEach(item => {
+                    if (filter === 'all' || item.classList.contains(filter)) {
+                        item.style.display = '';
+                    } else {
+                        item.style.display = 'none';
+                    }
+                });
             }
-            return response.json();
-        })
-        .then(data => {
-            const allProjects = data.proyectos;
-            renderProjects(allProjects); // Renderizar todos los proyectos inicialmente
 
-            // Añadir funcionalidad de filtrado
             filterButtons.forEach(button => {
                 button.addEventListener('click', function() {
                     filterButtons.forEach(btn => btn.classList.remove('active'));
                     this.classList.add('active');
-
-                    const filterValue = this.getAttribute('data-filter');
-                    
-                    if (filterValue === 'all') {
-                        renderProjects(allProjects);
-                    } else {
-                        const filteredProjects = allProjects.filter(project => project.categoria.includes(filterValue));
-                        renderProjects(filteredProjects);
-                    }
+                    applyFilter(this.getAttribute('data-filter'));
                 });
             });
-        })
-        .catch(error => console.error('Error al cargar los proyectos:', error));
+
+            applyFilter('all');
+        });
+    }
 });


### PR DESCRIPTION
## Summary
- centralize project loading in `loadProjects` with Spanish field support
- use the shared loader in home and portfolio pages and remove duplicate code

## Testing
- `npm test` *(fails: no such file or directory, open '/workspace/mespdesingweb/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c43bfae9488331b3292d689447d05e