### PR TITLE
Fix SEO JSON fetch paths

### DIFF
--- a/assets/js/seo.js
+++ b/assets/js/seo.js
@@ -2,8 +2,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const pageId = document.body.dataset.pageId;
 
     Promise.all([
-        fetch('/assets/seo/site.json').then(res => res.json()),
-        fetch(`/assets/seo/${pageId}.json`).then(res => res.json()).catch(() => ({}))
+        fetch('assets/seo/site.json').then(res => res.json()),
+        fetch(`assets/seo/${pageId}.json`).then(res => res.json()).catch(() => ({}))
     ])
     .then(([siteData, pageData]) => {
         // Combinar datos globales y de la página


### PR DESCRIPTION
## Summary
- Use relative paths for global and page-level SEO JSON fetches.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c43bfb43c08331a534ac6a9f76a3e9